### PR TITLE
Quick fix for shebang

### DIFF
--- a/tasktime.py
+++ b/tasktime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Sven Hertle <sven.hertle@googlemail.com>
 


### PR DESCRIPTION
This should make the script more universal and allows the system to indicate where the python3 interpreter is located by using env.

This specifically fixes the script for me on OS X.
